### PR TITLE
[bug] don't open new shell when ___X_CMD_XBINEXP_EXIT is set

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,9 @@ ___x_cmd_get_bootinit()(
 );
 
 ___x_cmd_get_start(){
-    if [ -z "$___X_CMD_ROOT_MOD" ]; then
+    if [ -n "$___X_CMD_XBINEXP_EXIT" ]; then
+        ___x_cmd_get_log "This installation/upgrade is performed by an external call, so the interactive shell for the new version will not automatically open.";
+    elif [ -z "$___X_CMD_ROOT_MOD" ]; then
         ___X_CMD_ROOT_CODE=;
         . "$___X_CMD_ROOT/v/$___X_CMD_VERSION/X";
     elif [ "${-#*i}" != "$-" ]; then


### PR DESCRIPTION
Please double check the logic ~

To solve issue: https://github.com/x-cmd/x-cmd/issues/122